### PR TITLE
Keep only one panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "johnnys-brackets-builder",
+    "name": "brackets-builder",
     "title": "Brackets Builder",
     "description": "Allow to run build programs (such as running Python/Ruby/Node/etc scripts) from Brackets and display results in panel. It is possible to create own build systems via 'Edit>Edit Builder' menu item and editing opened JSON-file (you need to restart Brackets). Press Ctrl(Cmd)-B to build current file.",
     "homepage": "https://github.com/vhornets/brackets-builder",


### PR DESCRIPTION
I edited the client code to show only one builder panel. More panels are just useless.

Nice plugin! 
