### PR TITLE
Removing "\r" when followed by a "\n" for Windows systems

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -1,14 +1,14 @@
 [
     {
         "name": "Python",
-        "cmd": "python $FILE"
+        "cmd": "python \"$FILE\""
     },
     {
         "name": "JavaScript",
-        "cmd": "node $FILE"
+        "cmd": "node \"$FILE\""
     },
     {
         "name": "Ruby",
-        "cmd": "ruby $FILE"
+        "cmd": "ruby \"$FILE\""
     }
 ]

--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
                 panel.show();
             })
             .then(function (data) {
-                $('#builder-panel .builder-content').html(_processCmdOutput(data));
+                $('#builder-panel .builder-content').html(_processCmdOutput(data.replace("\r\n", "\n")));
                 panel.show();
             });
         }).done();


### PR DESCRIPTION
I have improved the output for Windows since it will print a `\r` before making a newline.

I also added quotes around `$FILE` to manage paths with spaces.
